### PR TITLE
Example for Result type helpers

### DIFF
--- a/app/com/knoldus/controllers/resultHelpers/ResultHelpers.java
+++ b/app/com/knoldus/controllers/resultHelpers/ResultHelpers.java
@@ -1,0 +1,32 @@
+package com.knoldus.controllers.resultHelpers;
+
+import play.mvc.Controller;
+import play.mvc.Result;
+
+public class ResultHelpers extends Controller {
+
+  public Result okType() {
+    return ok(com.knoldus.views.html.index.render("Ok Type Result...!!"));
+  }
+
+  public Result notFoundType() {
+    return ok(views.html.defaultpages.notFound.render("Not found Type Result ....!!", "/notFound"));
+  }
+
+  public Result pageNotFoundType() {
+    return notFound("<h1>Page not found</h1>").as("text/html");
+  }
+
+  public Result badRequestType() {
+    return ok(views.html.defaultpages.badRequest
+        .render("", "/badRequest", "Bad Request Type Result ....!"));
+  }
+
+  public Result internalServerType() {
+    return internalServerError("Oops ! Internal Server Error");
+  }
+
+  public Result strangeResponseType() {
+    return status(420, "Strange Response Type");
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -20,3 +20,12 @@ GET     /assets/*file        controllers.Assets.versioned(path="/public", file: 
 #JPA routes
 GET     /add-emp                   com.knoldus.controllers.jpa.EmployeeController.addNewEmployee
 GET     /emp-update/:id            com.knoldus.controllers.jpa.EmployeeController.updateEmployee(id: Int)
+
+#Result Types
+GET      /ok                         com.knoldus.controllers.resultHelpers.ResultHelpers.okType
+GET      /notfound                       com.knoldus.controllers.resultHelpers.ResultHelpers.notFoundType
+GET      /pagenotfound                    com.knoldus.controllers.resultHelpers.ResultHelpers.pageNotFoundType
+GET      /badrequest                      com.knoldus.controllers.resultHelpers.ResultHelpers.badRequestType
+GET      /internalservererror                    com.knoldus.controllers.resultHelpers.ResultHelpers.internalServerType
+GET      /status                      com.knoldus.controllers.resultHelpers.ResultHelpers.strangeResponseType
+


### PR DESCRIPTION
    
Following routes will demonstrate result of each type :
     /ok                             
     /notfound                      
     /pagenotfound                    
    /badrequest                      
    /internalservererror                    
    /status   